### PR TITLE
MongoId.converter() was deleted in trafaret

### DIFF
--- a/aiohttp_admin/backends/mongo_utils.py
+++ b/aiohttp_admin/backends/mongo_utils.py
@@ -55,9 +55,6 @@ def check_comparator(column, comparator):
 def apply_trafaret(trafaret, value):
     validate = trafaret.check_and_return
 
-    if isinstance(trafaret, MongoId):
-        validate = trafaret.check_and_return
-
     if isinstance(value, list):
         try:
             value = validate(value)


### PR DESCRIPTION
MongoId.converter() code was moved in trafaret into .check_and_return()