### PR TITLE
Improvements to edit/create forms

### DIFF
--- a/admin-js/src/App.js
+++ b/admin-js/src/App.js
@@ -1,6 +1,7 @@
 import {
     Admin, Create, Datagrid, DatagridConfigurable, Edit, EditButton, List, HttpError, Resource, SimpleForm,
     SelectColumnsButton, CreateButton, FilterButton, ExportButton, TopToolbar,
+    DeleteButton, SaveButton, Toolbar,
     AppBar, InspectorButton, Layout, TitlePortal,
     BulkDeleteButton, BulkExportButton, BulkUpdateButton,
     SimpleShowLayout, Show,
@@ -237,17 +238,28 @@ const AiohttpShow = (resource, name, permissions) => (
     </Show>
 );
 
-const AiohttpEdit = (resource, name, permissions) => (
-    <Edit>
-        <SimpleForm>
-            {createInputs(resource, name, "edit", permissions)}
-        </SimpleForm>
-    </Edit>
-);
+const AiohttpEdit = (resource, name, permissions) => {
+    const AiohttpEditToolbar = props => (
+        <Toolbar {...props} sx={{ display: "flex", justifyContent: "space-between" }}>
+            <SaveButton />
+            <WithRecord render={
+                (record) => hasPermission(`${name}.delete`, permissions, record) && <DeleteButton />
+            } />
+        </Toolbar>
+    );
+
+    return(
+        <Edit mutationMode="pessimistic">
+            <SimpleForm toolbar={<AiohttpEditToolbar />} sanitizeEmptyValues>
+                {createInputs(resource, name, "edit", permissions)}
+            </SimpleForm>
+        </Edit>
+    );
+}
 
 const AiohttpCreate = (resource, name, permissions) => (
     <Create>
-        <SimpleForm>
+        <SimpleForm sanitizeEmptyValues>
             {createInputs(resource, name, "add", permissions)}
         </SimpleForm>
     </Create>


### PR DESCRIPTION
- Display delete button only when user has permission.
- Use pessimistic edit mode, so changes are confirmed by the server before redirect.
- sanitizeEmptyValues to skip sending empty values for inputs.