### PR TITLE
Use str IDs for API

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -23,6 +23,10 @@ warn_return_any = True
 warn_unreachable = True
 warn_unused_ignores = True
 
+[mypy-aiohttp_admin.backends.sqlalchemy]
+# We use Any for several parameters, causing a few of these errors.
+disallow_any_decorated = False
+
 [mypy-tests.*]
 disallow_any_decorated = False
 disallow_untyped_calls = False

--- a/admin-js/src/App.js
+++ b/admin-js/src/App.js
@@ -105,7 +105,7 @@ function dataRequest(resource, endpoint, params) {
     for (const [k, v] of Object.entries(params)) {
         if (v === undefined)
             delete params[k];
-        if (typeof v === "object" && v !== null)
+        else if (typeof v === "object" && v !== null)
             params[k] = JSON.stringify(v);
     }
     const query = new URLSearchParams(params).toString();

--- a/aiohttp_admin/backends/abc.py
+++ b/aiohttp_admin/backends/abc.py
@@ -3,11 +3,12 @@ import json
 import sys
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from datetime import date, datetime, time
 from enum import Enum
 from functools import cached_property, partial
 from types import MappingProxyType
-from typing import Any, Literal, Optional, Union
+from typing import Any, Generic, Literal, Optional, TypeVar, Union, final
 
 from aiohttp import web
 from aiohttp_security import check_permission, permits
@@ -26,7 +27,9 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import TypedDict
 
+_ID = TypeVar("_ID")
 Record = dict[str, object]
+Meta = Optional[dict[str, object]]
 
 INPUT_TYPES = MappingProxyType({
     "BooleanInput": bool,
@@ -63,7 +66,7 @@ class _Sort(TypedDict):
 
 
 class _Params(TypedDict, total=False):
-    meta: dict[str, object]
+    meta: Meta
 
 
 class GetListParams(_Params):
@@ -73,11 +76,11 @@ class GetListParams(_Params):
 
 
 class GetOneParams(_Params):
-    id: Union[int, str]
+    id: str
 
 
 class GetManyParams(_Params):
-    ids: Json[list[Union[int, str]]]
+    ids: Json[tuple[str, ...]]
 
 
 class CreateParams(_Params):
@@ -85,31 +88,33 @@ class CreateParams(_Params):
 
 
 class UpdateParams(_Params):
-    id: Union[int, str]
+    id: str
     data: Json[Record]
     previousData: Json[Record]
 
 
 class UpdateManyParams(_Params):
-    ids: Json[list[Union[int, str]]]
+    ids: Json[tuple[str, ...]]
     data: Json[Record]
 
 
 class DeleteParams(_Params):
-    id: Union[int, str]
+    id: str
     previousData: Json[Record]
 
 
 class DeleteManyParams(_Params):
-    ids: Json[list[Union[int, str]]]
+    ids: Json[tuple[str, ...]]
 
 
-class AbstractAdminResource(ABC):
+class AbstractAdminResource(ABC, Generic[_ID]):
     name: str
     fields: dict[str, ComponentState]
     inputs: dict[str, InputState]
     primary_key: str
     omit_fields: set[str]
+    _id_type: type[_ID]
+    _foreign_rows: set[str]
 
     def __init__(self, record_type: Optional[dict[str, TypeAlias]] = None) -> None:
         if "id" in self.fields and self.primary_key != "id":
@@ -118,8 +123,10 @@ class AbstractAdminResource(ABC):
         # For runtime type checking only.
         if record_type is None:
             record_type = {k: Any for k in self.inputs}
+        self._raw_record_type = record_type
         self._record_type = TypedDict("RecordType", record_type, total=False)  # type: ignore[misc]
 
+    @final
     async def filter_by_permissions(self, request: web.Request, perm_type: str,
                                     record: Record, original: Optional[Record] = None) -> Record:
         """Return a filtered record containing permissible fields only."""
@@ -132,35 +139,36 @@ class AbstractAdminResource(ABC):
         """Return list of records and total count available (when not paginating)."""
 
     @abstractmethod
-    async def get_one(self, params: GetOneParams) -> Record:
+    async def get_one(self, record_id: _ID, meta: Meta) -> Record:
         """Return the matching record."""
 
     @abstractmethod
-    async def get_many(self, params: GetManyParams) -> list[Record]:
+    async def get_many(self, record_ids: Sequence[_ID], meta: Meta) -> list[Record]:
         """Return the matching records."""
 
     @abstractmethod
-    async def update(self, params: UpdateParams) -> Record:
+    async def update(self, record_id: _ID, data: Record, previous_data: Record, meta: Meta) -> Record:
         """Update the record and return the updated record."""
 
     @abstractmethod
-    async def update_many(self, params: UpdateManyParams) -> list[Union[int, str]]:
+    async def update_many(self, record_ids: Sequence[_ID], data: Record, meta: Meta) -> list[_ID]:
         """Update multiple records and return the IDs of updated records."""
 
     @abstractmethod
-    async def create(self, params: CreateParams) -> Record:
+    async def create(self, data: Record, meta: Meta) -> Record:
         """Create a new record and return the created record."""
 
     @abstractmethod
-    async def delete(self, params: DeleteParams) -> Record:
+    async def delete(self, record_id: _ID, previous_data: Record, meta: Meta) -> Record:
         """Delete a record and return the deleted record."""
 
     @abstractmethod
-    async def delete_many(self, params: DeleteManyParams) -> list[Union[int, str]]:
+    async def delete_many(self, record_ids: Sequence[_ID], meta: Meta) -> list[_ID]:
         """Delete the matching records and return their IDs."""
 
     # https://marmelab.com/react-admin/DataProviderWriting.html
 
+    @final
     async def _get_list(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.view", context=(request, None))
         query = check(GetListParams, request.query)
@@ -178,146 +186,166 @@ class AbstractAdminResource(ABC):
             query["filter"][k] = v
 
         results, total = await self.get_list(query)
-        results = [await self.filter_by_permissions(request, "view", r) for r in results]
-        results = [r for r in results if await permits(request, f"admin.{self.name}.view",
-                                                       context=(request, r))]
-        # We need to set "id" for react-admin (in case there is no "id" primary key).
-        for r in results:
-            r["id"] = r[self.primary_key]
+        results = [await self._convert_record(r, request) for r in results
+                   if await permits(request, f"admin.{self.name}.view", context=(request, r))]
         return json_response({"data": results, "total": total})
 
+    @final
     async def _get_one(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.view", context=(request, None))
         query = check(GetOneParams, request.query)
+        record_id = check(self._id_type, query["id"])
 
-        result = await self.get_one(query)
+        result = await self.get_one(record_id, query.get("meta"))
         if not await permits(request, f"admin.{self.name}.view", context=(request, result)):
             raise web.HTTPForbidden()
-        result = await self.filter_by_permissions(request, "view", result)
-        result["id"] = result[self.primary_key]
-        return json_response({"data": result})
+        return json_response({"data": await self._convert_record(result, request)})
 
+    @final
     async def _get_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.view", context=(request, None))
         query = check(GetManyParams, request.query)
+        record_ids = check(tuple[self._id_type, ...], query["ids"])
 
-        results = await self.get_many(query)
+        results = await self.get_many(record_ids, query.get("meta"))
         if not results:
             raise web.HTTPNotFound()
 
-        results = [await self.filter_by_permissions(request, "view", r) for r in results
+        results = [await self._convert_record(r, request) for r in results
                    if await permits(request, f"admin.{self.name}.view", context=(request, r))]
-        for r in results:
-            r["id"] = r[self.primary_key]
         return json_response({"data": results})
 
+    @final
     async def _create(self, request: web.Request) -> web.Response:
         query = check(CreateParams, request.query)
         # TODO(Pydantic): Dissallow extra arguments
         for k in query["data"]:
             if k not in self.inputs and k != "id":
                 raise web.HTTPBadRequest(reason=f"Invalid field '{k}'")
-        query["data"] = check(self._record_type, query["data"])
-        await check_permission(request, f"admin.{self.name}.add", context=(request, query["data"]))
-        for k, v in query["data"].items():
+        data = self._check_record(query["data"])
+        await check_permission(request, f"admin.{self.name}.add", context=(request, data))
+        for k, v in data.items():
             if v is not None:
                 await check_permission(request, f"admin.{self.name}.{k}.add",
-                                       context=(request, query["data"]))
+                                       context=(request, data))
 
-        result = await self.create(query)
-        result = await self.filter_by_permissions(request, "view", result)
-        result["id"] = result[self.primary_key]
-        return json_response({"data": result})
+        result = await self.create(data, query.get("meta"))
+        return json_response({"data": await self._convert_record(result, request)})
 
+    @final
     async def _update(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.edit", context=(request, None))
         query = check(UpdateParams, request.query)
+        record_id = check(self._id_type, query["id"])
         # TODO(Pydantic): Dissallow extra arguments
         for k in query["data"]:
             if k not in self.inputs and k != "id":
                 raise web.HTTPBadRequest(reason=f"Invalid field '{k}'")
-        query["data"] = check(self._record_type, query["data"])
-        query["previousData"] = check(self._record_type, query["previousData"])
+        data = self._check_record(query["data"])
+        previous_data = self._check_record(query["previousData"])
 
         if self.primary_key != "id":
-            query["data"].pop("id", None)
+            data.pop("id", None)
 
         # Check original record is allowed by permission filters.
-        original = await self.get_one({"id": query["id"]})
+        original = await self.get_one(record_id, query.get("meta"))
         if not await permits(request, f"admin.{self.name}.edit", context=(request, original)):
             raise web.HTTPForbidden()
 
         # Filter rather than forbid because react-admin still sends fields without an
         # input component. The query may not be the complete dict though, so we must
         # pass original for testing.
-        query["data"] = await self.filter_by_permissions(request, "edit", query["data"], original)
+        data = await self.filter_by_permissions(request, "edit", data, original)
         # Check new values are allowed by permission filters.
-        if not await permits(request, f"admin.{self.name}.edit", context=(request, query["data"])):
+        if not await permits(request, f"admin.{self.name}.edit", context=(request, data)):
             raise web.HTTPForbidden()
 
-        if not query["data"]:
+        if not data:
             raise web.HTTPBadRequest(reason="No allowed fields to change.")
 
-        result = await self.update(query)
-        result = await self.filter_by_permissions(request, "view", result)
-        result["id"] = result[self.primary_key]
-        return json_response({"data": result})
+        result = await self.update(record_id, data, previous_data, query.get("meta"))
+        return json_response({"data": await self._convert_record(result, request)})
 
+    @final
     async def _update_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.edit", context=(request, None))
         query = check(UpdateManyParams, request.query)
+        record_ids = check(tuple[self._id_type, ...], query["ids"])
         # TODO(Pydantic): Dissallow extra arguments
         for k in query["data"]:
             if k not in self.inputs and k != "id":
                 raise web.HTTPBadRequest(reason=f"Invalid field '{k}'")
-        query["data"] = check(self._record_type, query["data"])
+        data = self._check_record(query["data"])
 
         # Check original records are allowed by permission filters.
-        originals = await self.get_many({"ids": query["ids"]})
+        originals = await self.get_many(record_ids, query.get("meta"))
         if not originals:
             raise web.HTTPNotFound()
         allowed = (permits(request, f"admin.{self.name}.edit", context=(request, r))
                    for r in originals)
         allowed_f = (permits(request, f"admin.{self.name}.{k}.edit", context=(request, r))
-                     for r in originals for k in query["data"])
+                     for r in originals for k in data)
         if not all(await asyncio.gather(*allowed, *allowed_f)):
             raise web.HTTPForbidden()
         # Check new values are allowed by permission filters.
-        if not await permits(request, f"admin.{self.name}.edit", context=(request, query["data"])):
+        if not await permits(request, f"admin.{self.name}.edit", context=(request, data)):
             raise web.HTTPForbidden()
 
-        ids = await self.update_many(query)
+        ids = await self.update_many(record_ids, data, query.get("meta"))
         # get_many() is called above, so we can be sure there will be results here.
-        return json_response({"data": ids})
+        return json_response({"data": self._convert_ids(ids)})
 
+    @final
     async def _delete(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.delete", context=(request, None))
         query = check(DeleteParams, request.query)
-        query["previousData"] = check(self._record_type, query["previousData"])
+        record_id = check(self._id_type, query["id"])
+        previous_data = self._check_record(query["previousData"])
 
-        original = await self.get_one({"id": query["id"]})
+        original = await self.get_one(record_id, query.get("meta"))
         if not await permits(request, f"admin.{self.name}.delete", context=(request, original)):
             raise web.HTTPForbidden()
 
-        result = await self.delete(query)
-        result = await self.filter_by_permissions(request, "view", result)
-        result["id"] = result[self.primary_key]
-        return json_response({"data": result})
+        result = await self.delete(record_id, previous_data, query.get("meta"))
+        return json_response({"data": await self._convert_record(result, request)})
 
+    @final
     async def _delete_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.delete", context=(request, None))
         query = check(DeleteManyParams, request.query)
+        record_ids = check(tuple[self._id_type, ...], query["ids"])
 
-        originals = await self.get_many(query)
+        originals = await self.get_many(record_ids, query.get("meta"))
         allowed = await asyncio.gather(*(permits(request, f"admin.{self.name}.delete",
                                                  context=(request, r)) for r in originals))
         if not all(allowed):
             raise web.HTTPForbidden()
 
-        ids = await self.delete_many(query)
+        ids = await self.delete_many(record_ids, query.get("meta"))
         if not ids:
             raise web.HTTPNotFound()
-        return json_response({"data": ids})
+        return json_response({"data": self._convert_ids(ids)})
+
+    @final
+    def _check_record(self, record: Record) -> Record:
+        """Check and convert input record."""
+        return check(self._record_type, record)
+
+    @final
+    async def _convert_record(self, record: Record, request: web.Request) -> Record:
+        """Convert record to correct output format."""
+        record = await self.filter_by_permissions(request, "view", record)
+        # We need to set "id" for react-admin (in case there is no "id" primary key).
+        record["id"] = str(record[self.primary_key])
+        # Convert foreign key values to correct IDs.
+        for k in self._foreign_rows:
+            record[k] = None if record[k] is None else str(record[k])
+        return record
+
+    @final
+    def _convert_ids(self, ids: Sequence[_ID]) -> tuple[str]:
+        """Convert IDs to correct output format."""
+        return tuple(str(i) for i in ids)
 
     @cached_property
     def routes(self) -> tuple[web.RouteDef, ...]:

--- a/aiohttp_admin/backends/abc.py
+++ b/aiohttp_admin/backends/abc.py
@@ -205,7 +205,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     async def _get_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.view", context=(request, None))
         query = check(GetManyParams, request.query)
-        record_ids = check(tuple[self._id_type, ...], query["ids"])
+        record_ids = check(tuple[self._id_type, ...], query["ids"])  # type: ignore[name-defined]
 
         results = await self.get_many(record_ids, query.get("meta"))
         if not results:
@@ -270,7 +270,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     async def _update_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.edit", context=(request, None))
         query = check(UpdateManyParams, request.query)
-        record_ids = check(tuple[self._id_type, ...], query["ids"])
+        record_ids = check(tuple[self._id_type, ...], query["ids"])  # type: ignore[name-defined]
         # TODO(Pydantic): Dissallow extra arguments
         for k in query["data"]:
             if k not in self.inputs and k != "id":
@@ -313,7 +313,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     async def _delete_many(self, request: web.Request) -> web.Response:
         await check_permission(request, f"admin.{self.name}.delete", context=(request, None))
         query = check(DeleteManyParams, request.query)
-        record_ids = check(tuple[self._id_type, ...], query["ids"])
+        record_ids = check(tuple[self._id_type, ...], query["ids"])  # type: ignore[name-defined]
 
         originals = await self.get_many(record_ids, query.get("meta"))
         allowed = await asyncio.gather(*(permits(request, f"admin.{self.name}.delete",
@@ -329,7 +329,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     @final
     def _check_record(self, record: Record) -> Record:
         """Check and convert input record."""
-        return check(self._record_type, record)
+        return check(self._record_type, record) # type: ignore[no-any-return]
 
     @final
     async def _convert_record(self, record: Record, request: web.Request) -> Record:
@@ -343,7 +343,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
         return record
 
     @final
-    def _convert_ids(self, ids: Sequence[_ID]) -> tuple[str]:
+    def _convert_ids(self, ids: Sequence[_ID]) -> tuple[str, ...]:
         """Convert IDs to correct output format."""
         return tuple(str(i) for i in ids)
 

--- a/aiohttp_admin/backends/abc.py
+++ b/aiohttp_admin/backends/abc.py
@@ -147,7 +147,8 @@ class AbstractAdminResource(ABC, Generic[_ID]):
         """Return the matching records."""
 
     @abstractmethod
-    async def update(self, record_id: _ID, data: Record, previous_data: Record, meta: Meta) -> Record:
+    async def update(self, record_id: _ID, data: Record, previous_data: Record,
+                     meta: Meta) -> Record:
         """Update the record and return the updated record."""
 
     @abstractmethod

--- a/aiohttp_admin/backends/abc.py
+++ b/aiohttp_admin/backends/abc.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, time
 from enum import Enum
 from functools import cached_property, partial
 from types import MappingProxyType
-from typing import Any, Generic, Literal, Optional, TypeVar, Union, final
+from typing import Any, Generic, Literal, Optional, TypeVar, final
 
 from aiohttp import web
 from aiohttp_security import check_permission, permits
@@ -329,7 +329,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     @final
     def _check_record(self, record: Record) -> Record:
         """Check and convert input record."""
-        return check(self._record_type, record) # type: ignore[no-any-return]
+        return check(self._record_type, record)  # type: ignore[no-any-return]
 
     @final
     async def _convert_record(self, record: Record, request: web.Request) -> Record:

--- a/aiohttp_admin/backends/sqlalchemy.py
+++ b/aiohttp_admin/backends/sqlalchemy.py
@@ -13,10 +13,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
 from sqlalchemy.sql.roles import ExpressionElementRole
 
-from .abc import (
-    AbstractAdminResource, CreateParams, DeleteManyParams, DeleteParams, GetListParams,
-    GetManyParams, GetOneParams, Record, UpdateManyParams, UpdateParams)
+from .abc import AbstractAdminResource, GetListParams, Meta, Record
 from ..types import FunctionState, comp, func, regex
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -155,7 +158,8 @@ def create_filters(columns: sa.ColumnCollection[str, sa.Column[object]],
             for k, v in filters.items())
 
 
-class SAResource(AbstractAdminResource):
+# ID is based on PK, which we can't infer from types, so must use Any here.
+class SAResource(AbstractAdminResource[Any]):
     def __init__(self, db: AsyncEngine, model_or_table: Union[sa.Table, type[DeclarativeBase]]):
         if isinstance(model_or_table, sa.Table):
             table = model_or_table
@@ -168,12 +172,14 @@ class SAResource(AbstractAdminResource):
         self.fields = {}
         self.inputs = {}
         self.omit_fields = set()
+        self._foreign_rows = set()
         record_type = {}
         for c in table.c.values():
             if c.foreign_keys:
                 field = "ReferenceField"
                 inp = "ReferenceInput"
                 key = next(iter(c.foreign_keys))  # TODO: Test composite foreign keys.
+                self._foreign_rows.add(c.name)
                 props: dict[str, Any] = {"reference": key.column.table.name,
                                          "target": key.column.name}
             else:
@@ -261,6 +267,7 @@ class SAResource(AbstractAdminResource):
             # TODO: Test composite primary key
             raise NotImplementedError("Composite keys not supported yet.")
         self.primary_key = pk[0]
+        self._id_type = table.c[pk[0]].type.python_type
 
         super().__init__(record_type)
 
@@ -286,56 +293,56 @@ class SAResource(AbstractAdminResource):
         return entities, count
 
     @handle_errors
-    async def get_one(self, params: GetOneParams) -> Record:
+    async def get_one(self, record_id: Any, meta: Meta) -> Record:
         async with self._db.connect() as conn:
-            stmt = sa.select(self._table).where(self._table.c[self.primary_key] == params["id"])
+            stmt = sa.select(self._table).where(self._table.c[self.primary_key] == record_id)
             result = await conn.execute(stmt)
             return result.one()._asdict()
 
     @handle_errors
-    async def get_many(self, params: GetManyParams) -> list[Record]:
+    async def get_many(self, record_ids: Sequence[Any], meta: Meta) -> list[Record]:
         async with self._db.connect() as conn:
-            stmt = sa.select(self._table).where(self._table.c[self.primary_key].in_(params["ids"]))
+            stmt = sa.select(self._table).where(self._table.c[self.primary_key].in_(record_ids))
             result = await conn.execute(stmt)
             return [r._asdict() for r in result]
 
     @handle_errors
-    async def create(self, params: CreateParams) -> Record:
+    async def create(self, data: Record, meta: Meta) -> Record:
         async with self._db.begin() as conn:
-            stmt = sa.insert(self._table).values(params["data"]).returning(*self._table.c)
+            stmt = sa.insert(self._table).values(data).returning(*self._table.c)
             try:
                 row = await conn.execute(stmt)
             except sa.exc.IntegrityError:
-                logger.warning("IntegrityError (%s)", params["data"], exc_info=True)
+                logger.warning("IntegrityError (%s)", data, exc_info=True)
                 raise web.HTTPBadRequest(reason="Integrity error (element already exists?)")
             return row.one()._asdict()
 
     @handle_errors
-    async def update(self, params: UpdateParams) -> Record:
+    async def update(self, record_id: Any, data: Record, previous_data: Record, meta: Meta) -> Record:
         async with self._db.begin() as conn:
-            stmt = sa.update(self._table).where(self._table.c[self.primary_key] == params["id"])
-            stmt = stmt.values(params["data"]).returning(*self._table.c)
+            stmt = sa.update(self._table).where(self._table.c[self.primary_key] == record_id)
+            stmt = stmt.values(data).returning(*self._table.c)
             row = await conn.execute(stmt)
             return row.one()._asdict()
 
     @handle_errors
-    async def update_many(self, params: UpdateManyParams) -> list[Union[str, int]]:
+    async def update_many(self, record_ids: Sequence[Any], data: Record, meta: Meta) -> list[Any]:
         async with self._db.begin() as conn:
-            stmt = sa.update(self._table).where(self._table.c[self.primary_key].in_(params["ids"]))
-            stmt = stmt.values(params["data"]).returning(self._table.c[self.primary_key])
+            stmt = sa.update(self._table).where(self._table.c[self.primary_key].in_(record_ids))
+            stmt = stmt.values(data).returning(self._table.c[self.primary_key])
             return list(await conn.scalars(stmt))
 
     @handle_errors
-    async def delete(self, params: DeleteParams) -> Record:
+    async def delete(self, record_id: Any, previous_data: Record, meta: Meta) -> Record:
         async with self._db.begin() as conn:
-            stmt = sa.delete(self._table).where(self._table.c[self.primary_key] == params["id"])
+            stmt = sa.delete(self._table).where(self._table.c[self.primary_key] == record_id)
             row = await conn.execute(stmt.returning(*self._table.c))
             return row.one()._asdict()
 
     @handle_errors
-    async def delete_many(self, params: DeleteManyParams) -> list[Union[str, int]]:
+    async def delete_many(self, record_ids: Sequence[Any], meta: Meta) -> list[Any]:
         async with self._db.begin() as conn:
-            stmt = sa.delete(self._table).where(self._table.c[self.primary_key].in_(params["ids"]))
+            stmt = sa.delete(self._table).where(self._table.c[self.primary_key].in_(record_ids))
             r = await conn.scalars(stmt.returning(self._table.c[self.primary_key]))
             return list(r)
 

--- a/aiohttp_admin/backends/sqlalchemy.py
+++ b/aiohttp_admin/backends/sqlalchemy.py
@@ -16,11 +16,6 @@ from sqlalchemy.sql.roles import ExpressionElementRole
 from .abc import AbstractAdminResource, GetListParams, Meta, Record
 from ..types import FunctionState, comp, func, regex
 
-if sys.version_info >= (3, 12):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:

--- a/aiohttp_admin/backends/sqlalchemy.py
+++ b/aiohttp_admin/backends/sqlalchemy.py
@@ -313,7 +313,8 @@ class SAResource(AbstractAdminResource[Any]):
             return row.one()._asdict()
 
     @handle_errors
-    async def update(self, record_id: Any, data: Record, previous_data: Record, meta: Meta) -> Record:
+    async def update(self, record_id: Any, data: Record, previous_data: Record,
+                     meta: Meta) -> Record:
         async with self._db.begin() as conn:
             stmt = sa.update(self._table).where(self._table.c[self.primary_key] == record_id)
             stmt = stmt.values(data).returning(*self._table.c)

--- a/tests/_resources.py
+++ b/tests/_resources.py
@@ -1,12 +1,10 @@
-from typing import Union
+from typing import Sequence, Union
 
-from aiohttp_admin.backends.abc import (
-    AbstractAdminResource, CreateParams, DeleteManyParams, DeleteParams, GetListParams,
-    GetManyParams, GetOneParams, Record, UpdateManyParams, UpdateParams)
+from aiohttp_admin.backends.abc import AbstractAdminResource, GetListParams, Meta, Record
 from aiohttp_admin.types import ComponentState, InputState
 
 
-class DummyResource(AbstractAdminResource):
+class DummyResource(AbstractAdminResource[str]):
     def __init__(self, name: str, fields: dict[str, ComponentState],
                  inputs: dict[str, InputState], primary_key: str):
         self.name = name
@@ -14,28 +12,30 @@ class DummyResource(AbstractAdminResource):
         self.inputs = inputs
         self.primary_key = primary_key
         self.omit_fields = set()
+        self._pk_type = str
+        self._foreign_rows = set()
         super().__init__()
 
     async def get_list(self, params: GetListParams) -> tuple[list[Record], int]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
-    async def get_one(self, params: GetOneParams) -> Record:  # pragma: no cover
+    async def get_one(self, record_id: str, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def get_many(self, params: GetManyParams) -> list[Record]:  # pragma: no cover
+    async def get_many(self, record_ids: Sequence[str], meta: Meta) -> list[Record]:  # pragma: no cover
         raise NotImplementedError()
 
-    async def update(self, params: UpdateParams) -> Record:  # pragma: no cover
+    async def update(self, record_id: str, data: Record, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def update_many(self, params: UpdateManyParams) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
+    async def update_many(self, record_ids: Sequence[str], data: Record, meta: Meta) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
-    async def create(self, params: CreateParams) -> Record:  # pragma: no cover
+    async def create(self, data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def delete(self, params: DeleteParams) -> Record:  # pragma: no cover
+    async def delete(self, record_id: str, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def delete_many(self, params: DeleteManyParams) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
+    async def delete_many(self, record_ids: Sequence[str], meta: Meta) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()

--- a/tests/_resources.py
+++ b/tests/_resources.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from typing import Sequence
 
 from aiohttp_admin.backends.abc import AbstractAdminResource, GetListParams, Meta, Record
 from aiohttp_admin.types import ComponentState, InputState

--- a/tests/_resources.py
+++ b/tests/_resources.py
@@ -22,10 +22,10 @@ class DummyResource(AbstractAdminResource[str]):
     async def get_one(self, record_id: str, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def get_many(self, record_ids: Sequence[str], meta: Meta) -> list[Record]:  # pragma: no cover
+    async def get_many(self, record_ids: Sequence[str], meta: Meta) -> list[Record]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
-    async def update(self, record_id: str, data: Record, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
+    async def update(self, record_id: str, data: Record, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
     async def update_many(self, record_ids: Sequence[str], data: Record, meta: Meta) -> list[str]:  # pragma: no cover  # noqa: B950
@@ -34,7 +34,7 @@ class DummyResource(AbstractAdminResource[str]):
     async def create(self, data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def delete(self, record_id: str, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
+    async def delete(self, record_id: str, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
     async def delete_many(self, record_ids: Sequence[str], meta: Meta) -> list[str]:  # pragma: no cover  # noqa: B950

--- a/tests/_resources.py
+++ b/tests/_resources.py
@@ -28,7 +28,7 @@ class DummyResource(AbstractAdminResource[str]):
     async def update(self, record_id: str, data: Record, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def update_many(self, record_ids: Sequence[str], data: Record, meta: Meta) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
+    async def update_many(self, record_ids: Sequence[str], data: Record, meta: Meta) -> list[str]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()
 
     async def create(self, data: Record, meta: Meta) -> Record:  # pragma: no cover
@@ -37,5 +37,5 @@ class DummyResource(AbstractAdminResource[str]):
     async def delete(self, record_id: str, previous_data: Record, meta: Meta) -> Record:  # pragma: no cover
         raise NotImplementedError()
 
-    async def delete_many(self, record_ids: Sequence[str], meta: Meta) -> list[Union[int, str]]:  # pragma: no cover  # noqa: B950
+    async def delete_many(self, record_ids: Sequence[str], meta: Meta) -> list[str]:  # pragma: no cover  # noqa: B950
         raise NotImplementedError()

--- a/tests/_resources.py
+++ b/tests/_resources.py
@@ -12,7 +12,7 @@ class DummyResource(AbstractAdminResource[str]):
         self.inputs = inputs
         self.primary_key = primary_key
         self.omit_fields = set()
-        self._pk_type = str
+        self._id_type = str
         self._foreign_rows = set()
         super().__init__()
 

--- a/tests/test_backends_abc.py
+++ b/tests/test_backends_abc.py
@@ -13,4 +13,4 @@ async def test_create_with_null(admin_client: TestClient, login: _Login) -> None
     p = {"data": json.dumps({"msg": None})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200, await resp.text()
-        assert await resp.json() == {"data": {"id": 4, "msg": None}}
+        assert await resp.json() == {"data": {"id": "4", "msg": None}}

--- a/tests/test_backends_sqlalchemy.py
+++ b/tests/test_backends_sqlalchemy.py
@@ -118,11 +118,11 @@ async def test_binary(
     url = app["admin"].router["test_get_one"].url_for()
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "binary": "foo"}}
+        assert await resp.json() == {"data": {"id": "1", "binary": "foo"}}
 
     async with admin_client.get(url, params={"id": 2}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 2, "binary": "\x01�\x02"}}
+        assert await resp.json() == {"data": {"id": "2", "binary": "\x01�\x02"}}
 
 
 def test_fk(base: type[DeclarativeBase], mock_engine: AsyncEngine) -> None:
@@ -335,31 +335,31 @@ async def test_nonid_pk_api(
          "sort": json.dumps({"field": "id", "order": "DESC"}), "filter": "{}"}
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 8, "num": 8, "other": "bar"},
-                                              {"id": 5, "num": 5, "other": "foo"}], "total": 2}
+        assert await resp.json() == {"data": [{"id": "8", "num": 8, "other": "bar"},
+                                              {"id": "5", "num": 5, "other": "foo"}], "total": 2}
 
     url = app["admin"].router["test_get_one"].url_for()
     async with admin_client.get(url, params={"id": 8}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 8, "num": 8, "other": "bar"}}
+        assert await resp.json() == {"data": {"id": "8", "num": 8, "other": "bar"}}
 
     url = app["admin"].router["test_get_many"].url_for()
-    async with admin_client.get(url, params={"ids": "[5, 8]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["5", "8"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 5, "num": 5, "other": "foo"},
-                                              {"id": 8, "num": 8, "other": "bar"}]}
+        assert await resp.json() == {"data": [{"id": "5", "num": 5, "other": "foo"},
+                                              {"id": "8", "num": 8, "other": "bar"}]}
 
     url = app["admin"].router["test_create"].url_for()
     p = {"data": json.dumps({"num": 12, "other": "this"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 12, "num": 12, "other": "this"}}
+        assert await resp.json() == {"data": {"id": "12", "num": 12, "other": "this"}}
 
     url = app["admin"].router["test_update"].url_for()
     p1 = {"id": 5, "data": json.dumps({"id": 5, "other": "that"}), "previousData": "{}"}
     async with admin_client.put(url, params=p1, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 5, "num": 5, "other": "that"}}
+        assert await resp.json() == {"data": {"id": "5", "num": 5, "other": "that"}}
 
 
 async def test_datetime(
@@ -396,14 +396,14 @@ async def test_datetime(
     url = app["admin"].router["test_get_one"].url_for()
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "date": "2023-04-23",
+        assert await resp.json() == {"data": {"id": "1", "date": "2023-04-23",
                                               "time": "2023-01-02 03:04:00"}}
 
     url = app["admin"].router["test_create"].url_for()
     p = {"data": json.dumps({"date": "2024-05-09", "time": "2020-11-12 03:04:05"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 2, "date": "2024-05-09",
+        assert await resp.json() == {"data": {"id": "2", "date": "2024-05-09",
                                               "time": "2020-11-12 03:04:05"}}
 
 
@@ -473,11 +473,11 @@ async def test_record_type(
     p = {"data": json.dumps({"foo": True, "bar": 5})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "foo": True, "bar": 5}}
+        assert await resp.json() == {"data": {"id": "1", "foo": True, "bar": 5}}
     p = {"data": json.dumps({"foo": None, "bar": -1})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 2, "foo": None, "bar": -1}}
+        assert await resp.json() == {"data": {"id": "2", "foo": None, "bar": -1}}
 
     p = {"data": json.dumps({"foo": 5, "bar": "foo"})}
     async with admin_client.post(url, params=p, headers=h) as resp:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -394,7 +394,8 @@ async def test_permission_filter_list(create_admin_client: _CreateClient,  # typ
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": "4", "msg": "Foo"}, {"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}],
+            "data": [{"id": "4", "msg": "Foo"}, {"id": "2", "msg": "Test"},
+                     {"id": "1", "msg": "Test"}],
             "total": 3}
 
 
@@ -705,7 +706,8 @@ async def test_permission_filter_field_list(create_admin_client: _CreateClient, 
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": "3"}, {"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}], "total": 3}
+            "data": [{"id": "3"}, {"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}],
+            "total": 3}
 
 
 async def test_permission_filter_field_list2(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -723,7 +725,8 @@ async def test_permission_filter_field_list2(create_admin_client: _CreateClient,
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": "3", "msg": "Other"}, {"id": "2"}, {"id": "1", "msg": "Test"}], "total": 3}
+            "data": [{"id": "3", "msg": "Other"}, {"id": "2"}, {"id": "1", "msg": "Test"}],
+            "total": 3}
 
 
 async def test_permission_filter_field_get_one(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -41,7 +41,7 @@ async def test_valid_login_logout(admin_client: TestClient) -> None:
     h = {"Authorization": token}
     async with admin_client.get(get_one_url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1}}
+        assert await resp.json() == {"data": {"id": "1"}}
 
     # Continue to test logout
     logout_url = admin_client.app["admin"].router["logout"].url_for()
@@ -139,7 +139,7 @@ async def test_get_resource_with_permission(create_admin_client: _CreateClient, 
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1}}
+        assert await resp.json() == {"data": {"id": "1"}}
 
 
 async def test_get_resource_with_wildcard_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -155,7 +155,7 @@ async def test_get_resource_with_wildcard_permission(create_admin_client: _Creat
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1}}
+        assert await resp.json() == {"data": {"id": "1"}}
 
 
 async def test_get_resource_with_negative_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -178,7 +178,7 @@ async def test_get_resource_with_negative_permission(create_admin_client: _Creat
     url = admin_client.app["admin"].router["dummy2_get_one"].url_for()
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "1", "msg": "Test"}}
 
     url = admin_client.app["admin"].router["dummy2_create"].url_for()
     p = {"data": '{"msg": "Foo"}'}
@@ -203,7 +203,7 @@ async def test_list_resource_finegrained_permission(create_admin_client: _Create
          "sort": json.dumps({"field": "id", "order": "DESC"}), "filter": "{}"}
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 3}, {"id": 2}, {"id": 1}], "total": 3}
+        assert await resp.json() == {"data": [{"id": "3"}, {"id": "2"}, {"id": "1"}], "total": 3}
 
 
 async def test_get_resource_finegrained_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -219,7 +219,7 @@ async def test_get_resource_finegrained_permission(create_admin_client: _CreateC
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1}}
+        assert await resp.json() == {"data": {"id": "1"}}
 
 
 async def test_get_many_resource_finegrained_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -233,9 +233,9 @@ async def test_get_many_resource_finegrained_permission(create_admin_client: _Cr
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_get_many"].url_for()
     h = await login(admin_client)
-    async with admin_client.get(url, params={"ids": "[1]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["1"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 1}]}
+        assert await resp.json() == {"data": [{"id": "1"}]}
 
 
 async def test_create_resource_finegrained_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -257,7 +257,7 @@ async def test_create_resource_finegrained_permission(create_admin_client: _Crea
 
     async with admin_client.post(url, params={"data": "{}"}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4, "msg": None}}
+        assert await resp.json() == {"data": {"id": "4", "msg": None}}
 
 
 async def test_create_resource_filtered_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -279,7 +279,7 @@ async def test_create_resource_filtered_permission(create_admin_client: _CreateC
 
     async with admin_client.post(url, params={"data": "{}"}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4}}
+        assert await resp.json() == {"data": {"id": "4"}}
 
 
 async def test_update_resource_finegrained_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -296,7 +296,7 @@ async def test_update_resource_finegrained_permission(create_admin_client: _Crea
     p = {"id": 1, "data": json.dumps({"id": 222, "msg": "ABC"}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 222, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "222", "msg": "Test"}}
 
 
 async def test_update_resource_filtered_permission(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -313,7 +313,7 @@ async def test_update_resource_filtered_permission(create_admin_client: _CreateC
     p = {"id": 1, "data": json.dumps({"id": 222, "msg": "ABC"}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 222}}
+        assert await resp.json() == {"data": {"id": "222"}}
 
     async with admin_client.app["db"]() as sess:
         r = await sess.get(admin_client.app["model2"], 1)
@@ -333,7 +333,7 @@ async def test_update_many_resource_finegrained_permission(  # type: ignore[no-a
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[1]", "data": json.dumps({"msg": "ABC"})}
+    p = {"ids": '["1"]', "data": json.dumps({"msg": "ABC"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
         # TODO(aiohttp-security05)
@@ -354,7 +354,7 @@ async def test_delete_resource_filtered_permission(create_admin_client: _CreateC
     p = {"id": 1, "previousData": "{}"}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1}}
+        assert await resp.json() == {"data": {"id": "1"}}
 
 
 async def test_permissions_cached(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -394,7 +394,7 @@ async def test_permission_filter_list(create_admin_client: _CreateClient,  # typ
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": 4, "msg": "Foo"}, {"id": 2, "msg": "Test"}, {"id": 1, "msg": "Test"}],
+            "data": [{"id": "4", "msg": "Foo"}, {"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}],
             "total": 3}
 
 
@@ -413,7 +413,7 @@ async def test_permission_filter_list2(create_admin_client: _CreateClient,  # ty
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": 2, "msg": "Test"}, {"id": 1, "msg": "Test"}], "total": 2}
+            "data": [{"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}], "total": 2}
 
 
 async def test_permission_filter_get_one(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -428,7 +428,7 @@ async def test_permission_filter_get_one(create_admin_client: _CreateClient,  # 
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 2}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 2, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "2", "msg": "Test"}}
     async with admin_client.get(url, params={"id": 3}, headers=h) as resp:
         assert resp.status == 403
 
@@ -445,7 +445,7 @@ async def test_permission_filter_get_one2(create_admin_client: _CreateClient,  #
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 2}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 2, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "2", "msg": "Test"}}
     async with admin_client.get(url, params={"id": 3}, headers=h) as resp:
         assert resp.status == 403
 
@@ -460,10 +460,10 @@ async def test_permission_filter_get_many(create_admin_client: _CreateClient,  #
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_get_many"].url_for()
     h = await login(admin_client)
-    async with admin_client.get(url, params={"ids": "[2, 3]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["2", "3"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 2, "msg": "Test"}]}
-    async with admin_client.get(url, params={"ids": "[3]"}, headers=h) as resp:
+        assert await resp.json() == {"data": [{"id": "2", "msg": "Test"}]}
+    async with admin_client.get(url, params={"ids": '["3"]'}, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {"data": []}
 
@@ -478,10 +478,10 @@ async def test_permission_filter_get_many2(create_admin_client: _CreateClient,  
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_get_many"].url_for()
     h = await login(admin_client)
-    async with admin_client.get(url, params={"ids": "[2, 3]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["2", "3"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 2, "msg": "Test"}]}
-    async with admin_client.get(url, params={"ids": "[3]"}, headers=h) as resp:
+        assert await resp.json() == {"data": [{"id": "2", "msg": "Test"}]}
+    async with admin_client.get(url, params={"ids": '["3"]'}, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {"data": []}
 
@@ -499,7 +499,7 @@ async def test_permission_filter_create(create_admin_client: _CreateClient,  # t
     p = {"data": json.dumps({"msg": "Test"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "4", "msg": "Test"}}
     p = {"data": json.dumps({"msg": "Foo"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 403
@@ -518,7 +518,7 @@ async def test_permission_filter_create2(create_admin_client: _CreateClient,  # 
     p = {"data": json.dumps({"msg": "Test"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "4", "msg": "Test"}}
     p = {"data": json.dumps({"msg": "Foo"})}
     async with admin_client.post(url, params=p, headers=h) as resp:
         assert resp.status == 403
@@ -577,13 +577,13 @@ async def test_permission_filter_update_many(  # type: ignore[no-any-unimported]
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[3]", "data": json.dumps({"msg": "Test"})}
+    p = {"ids": '["3"]', "data": json.dumps({"msg": "Test"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1]", "data": json.dumps({"msg": "Foo"})}
+    p = {"ids": '["1"]', "data": json.dumps({"msg": "Foo"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]", "data": json.dumps({"msg": "Test"})}
+    p = {"ids": '["1", "2"]', "data": json.dumps({"msg": "Test"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
 
@@ -599,13 +599,13 @@ async def test_permission_filter_update_many2(  # type: ignore[no-any-unimported
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[3]", "data": json.dumps({"msg": "Test"})}
+    p = {"ids": '["3"]', "data": json.dumps({"msg": "Test"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1]", "data": json.dumps({"msg": "Foo"})}
+    p = {"ids": '["1"]', "data": json.dumps({"msg": "Foo"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]", "data": json.dumps({"msg": "Test"})}
+    p = {"ids": '["1", "2"]', "data": json.dumps({"msg": "Test"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
 
@@ -656,16 +656,16 @@ async def test_permission_filter_delete_many(create_admin_client: _CreateClient,
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_delete_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[2, 3]"}
+    p = {"ids": '["2", "3"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[3]"}
+    p = {"ids": '["3"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]"}
+    p = {"ids": '["1", "2"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [1, 2]}
+        assert await resp.json() == {"data": ["1", "2"]}
 
 
 async def test_permission_filter_delete_many2(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -678,16 +678,16 @@ async def test_permission_filter_delete_many2(create_admin_client: _CreateClient
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_delete_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[2, 3]"}
+    p = {"ids": '["2", "3"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[3]"}
+    p = {"ids": '["3"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]"}
+    p = {"ids": '["1", "2"]'}
     async with admin_client.delete(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [1, 2]}
+        assert await resp.json() == {"data": ["1", "2"]}
 
 
 async def test_permission_filter_field_list(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -705,7 +705,7 @@ async def test_permission_filter_field_list(create_admin_client: _CreateClient, 
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": 3}, {"id": 2, "msg": "Test"}, {"id": 1, "msg": "Test"}], "total": 3}
+            "data": [{"id": "3"}, {"id": "2", "msg": "Test"}, {"id": "1", "msg": "Test"}], "total": 3}
 
 
 async def test_permission_filter_field_list2(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -723,7 +723,7 @@ async def test_permission_filter_field_list2(create_admin_client: _CreateClient,
     async with admin_client.get(url, params=p, headers=h) as resp:
         assert resp.status == 200
         assert await resp.json() == {
-            "data": [{"id": 3, "msg": "Other"}, {"id": 2}, {"id": 1, "msg": "Test"}], "total": 3}
+            "data": [{"id": "3", "msg": "Other"}, {"id": "2"}, {"id": "1", "msg": "Test"}], "total": 3}
 
 
 async def test_permission_filter_field_get_one(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -738,10 +738,10 @@ async def test_permission_filter_field_get_one(create_admin_client: _CreateClien
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "1", "msg": "Test"}}
     async with admin_client.get(url, params={"id": 3}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 3}}
+        assert await resp.json() == {"data": {"id": "3"}}
 
 
 async def test_permission_filter_field_get_one2(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -756,10 +756,10 @@ async def test_permission_filter_field_get_one2(create_admin_client: _CreateClie
     h = await login(admin_client)
     async with admin_client.get(url, params={"id": 1}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "1", "msg": "Test"}}
     async with admin_client.get(url, params={"id": 3}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 3}}
+        assert await resp.json() == {"data": {"id": "3"}}
 
 
 async def test_permission_filter_field_get_many(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -772,9 +772,9 @@ async def test_permission_filter_field_get_many(create_admin_client: _CreateClie
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_get_many"].url_for()
     h = await login(admin_client)
-    async with admin_client.get(url, params={"ids": "[2, 3]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["2", "3"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 2, "msg": "Test"}, {"id": 3}]}
+        assert await resp.json() == {"data": [{"id": "2", "msg": "Test"}, {"id": "3"}]}
 
 
 async def test_permission_filter_field_get_many2(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -787,9 +787,9 @@ async def test_permission_filter_field_get_many2(create_admin_client: _CreateCli
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_get_many"].url_for()
     h = await login(admin_client)
-    async with admin_client.get(url, params={"ids": "[1, 3]"}, headers=h) as resp:
+    async with admin_client.get(url, params={"ids": '["1", "3"]'}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [{"id": 1, "msg": "Test"}, {"id": 3}]}
+        assert await resp.json() == {"data": [{"id": "1", "msg": "Test"}, {"id": "3"}]}
 
 
 async def test_permission_filter_field_create(create_admin_client: _CreateClient,  # type: ignore[no-any-unimported] # noqa: B950
@@ -807,7 +807,7 @@ async def test_permission_filter_field_create(create_admin_client: _CreateClient
         assert resp.status == 403
     async with admin_client.post(url, params={"data": "{}"}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4}}
+        assert await resp.json() == {"data": {"id": "4"}}
     async with admin_client.app["db"]() as sess:
         r = await sess.get(admin_client.app["model2"], 4)
         assert r.msg is None
@@ -828,7 +828,7 @@ async def test_permission_filter_field_create2(create_admin_client: _CreateClien
         assert resp.status == 403
     async with admin_client.post(url, params={"data": "{}"}, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 4, "msg": None}}
+        assert await resp.json() == {"data": {"id": "4", "msg": None}}
     async with admin_client.app["db"]() as sess:
         r = await sess.get(admin_client.app["model2"], 4)
         assert r.msg is None
@@ -851,11 +851,11 @@ async def test_permission_filter_field_update(create_admin_client: _CreateClient
     p = {"id": 1, "data": json.dumps({"msg": "Spam"}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "msg": "Spam"}}
+        assert await resp.json() == {"data": {"id": "1", "msg": "Spam"}}
     p = {"id": 2, "data": json.dumps({"id": 5}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 5}}
+        assert await resp.json() == {"data": {"id": "5"}}
     async with admin_client.app["db"]() as sess:
         r = await sess.get(admin_client.app["model2"], 2)
         assert r is None
@@ -873,18 +873,18 @@ async def test_permission_filter_field_update2(create_admin_client: _CreateClien
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update"].url_for()
     h = await login(admin_client)
-    p = {"id": 3, "data": json.dumps({"msg": "Spam"}), "previousData": "{}"}
+    p = {"id": "3", "data": json.dumps({"msg": "Spam"}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 400
         assert await resp.text() == "400: No allowed fields to change."
-    p = {"id": 1, "data": json.dumps({"msg": "Spam"}), "previousData": "{}"}
+    p = {"id": "1", "data": json.dumps({"msg": "Spam"}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 1, "msg": "Spam"}}
-    p = {"id": 2, "data": json.dumps({"id": 5}), "previousData": "{}"}
+        assert await resp.json() == {"data": {"id": "1", "msg": "Spam"}}
+    p = {"id": "2", "data": json.dumps({"id": 5}), "previousData": "{}"}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": {"id": 5, "msg": "Test"}}
+        assert await resp.json() == {"data": {"id": "5", "msg": "Test"}}
     async with admin_client.app["db"]() as sess:
         r = await sess.get(admin_client.app["model2"], 2)
         assert r is None
@@ -903,13 +903,13 @@ async def test_permission_filter_field_update_many(  # type: ignore[no-any-unimp
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[3]", "data": json.dumps({"msg": "Spam"})}
+    p = {"ids": '["3"]', "data": json.dumps({"msg": "Spam"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]", "data": json.dumps({"msg": "Spam"})}
+    p = {"ids": '["1", "2"]', "data": json.dumps({"msg": "Spam"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [1, 2]}
+        assert await resp.json() == {"data": ["1", "2"]}
 
 
 async def test_permission_filter_field_update_many2(  # type: ignore[no-any-unimported]
@@ -923,10 +923,10 @@ async def test_permission_filter_field_update_many2(  # type: ignore[no-any-unim
     assert admin_client.app
     url = admin_client.app["admin"].router["dummy2_update_many"].url_for()
     h = await login(admin_client)
-    p = {"ids": "[3]", "data": json.dumps({"msg": "Spam"})}
+    p = {"ids": '["3"]', "data": json.dumps({"msg": "Spam"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 403
-    p = {"ids": "[1, 2]", "data": json.dumps({"msg": "Spam"})}
+    p = {"ids": '["1", "2"]', "data": json.dumps({"msg": "Spam"})}
     async with admin_client.put(url, params=p, headers=h) as resp:
         assert resp.status == 200
-        assert await resp.json() == {"data": [1, 2]}
+        assert await resp.json() == {"data": ["1", "2"]}


### PR DESCRIPTION
As the IDs should be an internal identifier, we should stick to using str IDs in the API. These must then be converted to/from the native format of the backend. This should also prepare the way for composite key support.