### PR TITLE
Fix integration tests

### DIFF
--- a/admin-js/src/App.jsx
+++ b/admin-js/src/App.jsx
@@ -266,7 +266,7 @@ function createInputs(resource, name, perm_type, permissions) {
     return components;
 }
 
-function createBulkUpdates(resource, name, permissions) {
+function createBulkUpdates(resource, name, permissions, refresh) {
     let buttons = [];
     for (const [label, data] of Object.entries(resource["bulk_update"])) {
         let allowed = true;
@@ -277,7 +277,8 @@ function createBulkUpdates(resource, name, permissions) {
             }
         }
         if (allowed)
-            buttons.push(<BulkUpdateButton mutationMode="pessimistic" key={label} label={label} data={data} />);
+            buttons.push(<BulkUpdateButton mutationMode="pessimistic" key={label} label={label} data={data}
+                          mutationOptions={{onSettled: refresh}} />);
     }
     return buttons;
 }
@@ -294,13 +295,16 @@ const AiohttpList = (resource, name, permissions) => {
             <ExportButton />
         </TopToolbar>
     );
-    const BulkActionButtons = () => (
-        <>
-            {hasPermission(`${name}.edit`, permissions) && createBulkUpdates(resource, name, permissions)}
-            <BulkExportButton />
-            {hasPermission(`${name}.delete`, permissions) && <BulkDeleteButton mutationMode="pessimistic" />}
-        </>
-    );
+    const BulkActionButtons = () => {
+        const refresh = useRefresh();
+        return (
+            <>
+                {hasPermission(`${name}.edit`, permissions) && createBulkUpdates(resource, name, permissions, refresh)}
+                <BulkExportButton />
+                {hasPermission(`${name}.delete`, permissions) && <BulkDeleteButton mutationMode="pessimistic" />}
+            </>
+        );
+    };
     const filters = createInputs(resource, name, "view", permissions);
     // Remove inputs with duplicate sources.
     const filterSources = filters.map(c => c["props"]["source"]);

--- a/admin-js/tests/permissions.test.js
+++ b/admin-js/tests/permissions.test.js
@@ -49,7 +49,6 @@ describe("admin", () => {
         await userEvent.click(await screen.findByRole("button", {"name": "Set to 7"}));
         expect(await screen.findByText("Update 6 simples")).toBeInTheDocument();
         await userEvent.click(screen.getByRole("button", {"name": "Confirm"}));
-        return;  // Broken now
         await waitFor(() => screen.getAllByText("7"));
 
         const table = await screen.findByRole("table");

--- a/admin-js/tests/simple.test.js
+++ b/admin-js/tests/simple.test.js
@@ -40,7 +40,8 @@ test("parents are displayed", async () => {
 
     const rows = within(table).getAllByRole("row");
     const firstCells = within(rows[1]).getAllByRole("cell").slice(1, -1);
-    expect(firstCells.map((e) => e.textContent)).toEqual(["with child", "2/13/2023, 7:04:00 PM", "USD"]);
+    expect(firstCells.map((e) => e.textContent)).toEqual(
+        ["with child", new Date("2023-02-13T19:04:00").toLocaleString(), "USD"]);
     expect(within(firstCells[0]).getByRole("link")).toBeInTheDocument();
 });
 
@@ -68,7 +69,6 @@ test("filters work", async () => {
     const table = await within(main).findByRole("table");
     let rows = within(table).getAllByRole("row");
     expect(rows.length).toBeGreaterThan(2);
-    return;  // Broken now
     await userEvent.type(within(quickSearch).getByRole("spinbutton", {"name": "Id"}), "1");
 
     await waitFor(() => within(main).getByRole("button", {"name": "Add filter"}));
@@ -90,7 +90,6 @@ test("enum filter works", async () => {
     expect(within(table).getAllByRole("row").length).toBe(2);
     const record = within(table).getAllByRole("row")[1];
     await userEvent.click(currencySelect);
-    return;  // Broken now
     await userEvent.click(await screen.findByRole("option", {"name": "GBP"}));
 
     expect(await within(main).findByText("No results found")).toBeInTheDocument();
@@ -154,7 +153,6 @@ test("reference input filter", async () => {
     const optionsInitial = within(resultsInitial).getAllByRole("option");
     expect(optionsInitial.map(e => e.textContent)).toEqual(["first", "with child"]);
 
-    return;  // Broken now
     await userEvent.click(within(resultsInitial).getByRole("option", {"name": "first"}));
     await waitFor(() => expect(screen.queryByText("USD")).not.toBeInTheDocument());
     expect(await within(main).findByText("No results found")).toBeInTheDocument();

--- a/admin-js/tests/simple.test.js
+++ b/admin-js/tests/simple.test.js
@@ -40,8 +40,7 @@ test("parents are displayed", async () => {
 
     const rows = within(table).getAllByRole("row");
     const firstCells = within(rows[1]).getAllByRole("cell").slice(1, -1);
-    expect(firstCells.map((e) => e.textContent)).toEqual(
-        ["with child", new Date("2023-02-13T19:04:00").toLocaleString(), "USD"]);
+    expect(firstCells.map((e) => e.textContent)).toEqual(["with child", "2/13/2023, 7:04:00 PM", "USD"]);
     expect(within(firstCells[0]).getByRole("link")).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## What do these changes do?

Fixes the integration tests for issue #934:
- 3 tests were broken by an old @testing-library/dom / React Testing Library version mismatch. This has since been fixed in a later dependency bump so this merge just removes the early returns.
- The bulk update test in permissions.test.js was failing because `BulkUpdateButton` doesn't refresh on success in pessimistic mode so the list never reflected the update. This merge adds an explicit `useRefresh()` call to fix it.
   - I think a previous dependency mismatch may have hidden the issue rather than broken the test as such.

## Are there changes in behavior for the user?

Yes. Bulk updates now refresh the list after completion so users will see updated values immediately instead of potentially stale data.

## Related issue number

Fixes #934

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
