### PR TITLE
fix: encode composite PKs in bulk responses

### DIFF
--- a/aiohttp_admin/backends/abc.py
+++ b/aiohttp_admin/backends/abc.py
@@ -413,7 +413,7 @@ class AbstractAdminResource(ABC, Generic[_ID]):
     @final
     def _convert_ids(self, ids: Sequence[_ID]) -> tuple[str, ...]:
         """Convert IDs to correct output format."""
-        return tuple(str(i) for i in ids)
+        return tuple("|".join(str(part) for part in i) for i in ids)
 
     def _process_list_query(self, query: _ListQuery, request: web.Request) -> None:
         # When sort order refers to "id", this should be translated to primary key.

--- a/aiohttp_admin/backends/sqlalchemy.py
+++ b/aiohttp_admin/backends/sqlalchemy.py
@@ -411,8 +411,9 @@ class SAResource(AbstractAdminResource[tuple[Any, ...]]):
                           meta: Meta) -> list[tuple[Any, ...]]:
         async with self._db.begin() as conn:
             stmt = sa.delete(self._table).where(self._cmp_pk_many(record_ids))
-            stmt = stmt.returning(*(self._table.c[pk] for pk in self.primary_key))
-            return [tuple(row) for row in await conn.execute(stmt)]
+            result = await conn.execute(
+                stmt.returning(*(self._table.c[pk] for pk in self.primary_key)))
+            return [tuple(row) for row in result]
 
     def _cmp_pk(self, record_id: tuple[Any, ...]) -> Iterator[_SABoolExpression]:
         return (self._table.c[pk] == r_id for pk, r_id in zip(self.primary_key, record_id))

--- a/aiohttp_admin/backends/sqlalchemy.py
+++ b/aiohttp_admin/backends/sqlalchemy.py
@@ -396,7 +396,7 @@ class SAResource(AbstractAdminResource[tuple[Any, ...]]):
         async with self._db.begin() as conn:
             stmt = sa.update(self._table).where(self._cmp_pk_many(record_ids))
             stmt = stmt.values(data).returning(*(self._table.c[pk] for pk in self.primary_key))
-            return list(await conn.scalars(stmt))
+            return [tuple(row) for row in await conn.execute(stmt)]
 
     @handle_errors
     async def delete(self, record_id: tuple[Any, ...], previous_data: Record,
@@ -411,8 +411,8 @@ class SAResource(AbstractAdminResource[tuple[Any, ...]]):
                           meta: Meta) -> list[tuple[Any, ...]]:
         async with self._db.begin() as conn:
             stmt = sa.delete(self._table).where(self._cmp_pk_many(record_ids))
-            r = await conn.scalars(stmt.returning(*(self._table.c[pk] for pk in self.primary_key)))
-            return list(r)
+            stmt = stmt.returning(*(self._table.c[pk] for pk in self.primary_key))
+            return [tuple(row) for row in await conn.execute(stmt)]
 
     def _cmp_pk(self, record_id: tuple[Any, ...]) -> Iterator[_SABoolExpression]:
         return (self._table.c[pk] == r_id for pk, r_id in zip(self.primary_key, record_id))

--- a/tests/test_backends_sqlalchemy.py
+++ b/tests/test_backends_sqlalchemy.py
@@ -444,6 +444,98 @@ async def test_nonid_pk_api(
         assert await resp.json() == {"data": {"id": "5", "data": {"num": 5, "other": "that"}}}
 
 
+async def test_composite_pk_api(
+    base: DeclarativeBase, aiohttp_client: Callable[[web.Application], Awaitable[_Client]],
+    login: _Login
+) -> None:
+    class Compound(base):  # type: ignore[misc,valid-type]
+        __tablename__ = "compound"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        other: Mapped[int] = mapped_column(primary_key=True)
+        msg: Mapped[str]
+
+    app = web.Application()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    db = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(base.metadata.create_all)
+    async with db.begin() as sess:
+        sess.add(Compound(id=1, other=2, msg="a"))
+        sess.add(Compound(id=1, other=3, msg="b"))
+        sess.add(Compound(id=4, other=5, msg="c"))
+
+    schema: aiohttp_admin.Schema = {
+        "security": {
+            "check_credentials": check_credentials,
+            "secure": False
+        },
+        "resources": ({"model": SAResource(engine, Compound)},)
+    }
+    app[admin] = aiohttp_admin.setup(app, schema)
+
+    admin_client = await aiohttp_client(app)
+    assert admin_client.app
+    h = await login(admin_client)
+
+    url = app[admin].router["compound_get_list"].url_for()
+    p = {"pagination": json.dumps({"page": 1, "perPage": 10}),
+         "sort": json.dumps({"field": "other", "order": "ASC"}), "filter": "{}"}
+    async with admin_client.get(url, params=p, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {"data": [
+            {"id": "1|2", "data": {"id": 1, "other": 2, "msg": "a"}},
+            {"id": "1|3", "data": {"id": 1, "other": 3, "msg": "b"}},
+            {"id": "4|5", "data": {"id": 4, "other": 5, "msg": "c"}}], "total": 3}
+
+    url = app[admin].router["compound_get_one"].url_for()
+    async with admin_client.get(url, params={"id": "1|2"}, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {
+            "data": {"id": "1|2", "data": {"id": 1, "other": 2, "msg": "a"}}}
+
+    url = app[admin].router["compound_get_many"].url_for()
+    async with admin_client.get(url, params={"ids": '["1|2", "1|3"]'}, headers=h) as resp:
+        assert resp.status == 200
+        body = await resp.json()
+        assert {row["id"]: row["data"] for row in body["data"]} == {
+            "1|2": {"id": 1, "other": 2, "msg": "a"},
+            "1|3": {"id": 1, "other": 3, "msg": "b"}}
+
+    url = app[admin].router["compound_update"].url_for()
+    p1 = {"id": "1|2", "data": json.dumps({"id": "1|2", "data": {"msg": "z"}}),
+          "previousData": json.dumps({"id": "1|2", "data": {}})}
+    async with admin_client.put(url, params=p1, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {
+            "data": {"id": "1|2", "data": {"id": 1, "other": 2, "msg": "z"}}}
+
+    url = app[admin].router["compound_update_many"].url_for()
+    p_upd = {"ids": '["1|2", "1|3"]', "data": json.dumps({"msg": "bulk"})}
+    async with admin_client.put(url, params=p_upd, headers=h) as resp:
+        assert resp.status == 200
+        body = await resp.json()
+        assert sorted(body["data"]) == ["1|2", "1|3"]
+
+    url = app[admin].router["compound_get_one"].url_for()
+    async with admin_client.get(url, params={"id": "1|2"}, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {
+            "data": {"id": "1|2", "data": {"id": 1, "other": 2, "msg": "bulk"}}}
+    async with admin_client.get(url, params={"id": "1|3"}, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {
+            "data": {"id": "1|3", "data": {"id": 1, "other": 3, "msg": "bulk"}}}
+
+    url = app[admin].router["compound_delete_many"].url_for()
+    async with admin_client.delete(url, params={"ids": '["4|5"]'}, headers=h) as resp:
+        assert resp.status == 200
+        assert await resp.json() == {"data": ["4|5"]}
+
+    url = app[admin].router["compound_get_one"].url_for()
+    async with admin_client.get(url, params={"id": "4|5"}, headers=h) as resp:
+        assert resp.status == 404
+
+
 async def test_datetime(
     base: DeclarativeBase, aiohttp_client: Callable[[web.Application], Awaitable[_Client]],
     login: _Login


### PR DESCRIPTION
## Summary
- `updateMany` / `deleteMany` now return full pipe-joined IDs for composite primary keys (`"1|2"`), matching `getList` / `getOne` / `getMany`.
- SQLAlchemy bulk methods return every `RETURNING` PK column instead of `scalars()` (first column only).
- `_convert_ids` uses the same `"|".join(...)` encoding as `_convert_record`.
- Adds `test_composite_pk_api` covering list, get, update, bulk update, and bulk delete.

Fixes #1192

## Test plan
- [x] `pytest tests/test_backends_sqlalchemy.py::test_composite_pk_api`
- [x] Single-PK bulk tests still pass (`test_update_many`, `test_delete_many`)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)